### PR TITLE
[RFC] Use inout signature for update function.

### DIFF
--- a/MobiusCore/Source/EventProcessor.swift
+++ b/MobiusCore/Source/EventProcessor.swift
@@ -67,14 +67,9 @@ class EventProcessor<Model, Event, Effect>: Disposable, CustomDebugStringConvert
 
     func accept(_ event: Event) {
         access.guard {
-            if let current = self.currentModel {
-                let next = self.update.update(model: current, event: event)
-
-                if let newModel = next.model {
-                    self.currentModel = newModel
-                }
-
-                self.publisher.post(next)
+            if self.currentModel != nil {
+                let effects = self.update.update(into: &self.currentModel!, event: event)
+                self.publisher.post(.next(self.currentModel!, effects: effects))
             } else {
                 self.queuedEvents.append(event)
             }

--- a/MobiusCore/Source/LoggingAdaptors.swift
+++ b/MobiusCore/Source/LoggingAdaptors.swift
@@ -59,9 +59,9 @@ extension Update {
     func logging<L: MobiusLogger>(_ logger: L) -> Update where L.Model == Model, L.Event == Event, L.Effect == Effect {
         return Update { model, event in
             logger.willUpdate(model: model, event: event)
-            let next = self.update(model: model, event: event)
-            logger.didUpdate(model: model, event: event, next: next)
-            return next
+            let effects = self.update(into: &model, event: event)
+            logger.didUpdate(model: model, event: event, next: Next(model: model, effects: effects))
+            return effects
         }
     }
 }

--- a/MobiusCore/Test/EventProcessorTests.swift
+++ b/MobiusCore/Test/EventProcessorTests.swift
@@ -118,6 +118,7 @@ class EventProcessorTests: QuickSpec {
     }
 
     let testUpdate = Update<Int, Int, Int> { model, event in
-        Next.next(model + event)
+        model += event
+        return []
     }
 }

--- a/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusCore/Test/EventRouterDisposalLogicalRaceRegressionTest.swift
@@ -69,9 +69,7 @@ class EventRouterDisposalLogicalRaceRegressionTest: QuickSpec {
                     errorThrown = true
                 })
 
-                let update = Update<Model, Event, Effect> { _, _ in
-                    .dispatchEffects([.effect1])
-                }
+                let update = Update<Model, Event, Effect> { _, _ in [.effect1] }
 
                 controller = Mobius.loop(update: update, effectHandler: effectHandler)
                     .withEventSource(eventSource)

--- a/MobiusCore/Test/LoggingUpdateTests.swift
+++ b/MobiusCore/Test/LoggingUpdateTests.swift
@@ -29,20 +29,22 @@ class LoggingUpdateTests: QuickSpec {
 
             beforeEach {
                 logger = TestMobiusLogger()
-                loggingUpdate = Update { model, event in Next(model: model, effects: [event]) }.logging(logger)
+                loggingUpdate = Update { _, event in [event] }.logging(logger)
             }
 
             it("should log willUpdate and didUpdate for each update attempt") {
-                _ = loggingUpdate.update(model: "from this", event: "ee")
+                var model = "from this"
+                _ = loggingUpdate.update(into: &model, event: "ee")
 
                 expect(logger.logMessages).to(equal(["willUpdate(from this, ee)", "didUpdate(from this, ee, (\"from this\", [\"ee\"]))"]))
             }
 
             it("should return update from delegate") {
-                let next = loggingUpdate.update(model: "hey", event: "event/effect")
+                var model = "hey"
+                let effects = loggingUpdate.update(into: &model, event: "event/effect")
 
-                expect(next.model).to(equal("hey"))
-                expect(next.effects).to(equal(["event/effect"]))
+                expect(model).to(equal("hey"))
+                expect(effects).to(equal(["event/effect"]))
             }
         }
     }

--- a/MobiusCore/Test/MobiusControllerTests.swift
+++ b/MobiusCore/Test/MobiusControllerTests.swift
@@ -46,7 +46,7 @@ class MobiusControllerTests: QuickSpec {
                 view = RecordingTestConnectable(expectedQueue: self.viewQueue)
                 let loopQueue = self.loopQueue
 
-                let updateFunction = Update<String, String, String> { model, event in
+                let updateFunction = Update<String, String, String>.create { model, event in
                     dispatchPrecondition(condition: .onQueue(loopQueue))
                     return .next("\(model)-\(event)")
                 }
@@ -136,7 +136,7 @@ class MobiusControllerTests: QuickSpec {
                     beforeEach {
                         modelObserver = MockConnectable()
                         effectObserver = MockConnectable()
-                        controller = Mobius.loop(update: Update { _, _ in .noChange }, effectHandler: effectObserver)
+                        controller = Mobius.loop(update: Update { _, _ in [] }, effectHandler: effectObserver)
                             .makeController(from: "")
                         controller.connectView(modelObserver)
                         controller.start()

--- a/MobiusCore/Test/MobiusIntegrationTests.swift
+++ b/MobiusCore/Test/MobiusIntegrationTests.swift
@@ -37,18 +37,23 @@ class MobiusIntegrationTests: QuickSpec {
                     }
                 }
 
-                let update = Update<String, String, String> { _, event in
+                let update = Update<String, String, String> { model, event in
                     switch event {
                     case "button pushed":
-                        return Next.next("pushed")
+                        model = "pushed"
+                        return []
                     case "trigger effect":
-                        return Next.next("triggered", effects: ["leads to event"])
+                        model = "triggered"
+                        return ["leads to event"]
                     case "effect feedback":
-                        return Next.next("done")
+                        model = "done"
+                        return []
                     case "from source":
-                        return Next.next("event sourced")
+                        model = "event sourced"
+                        return []
                     default:
-                        fatalError("unexpected event \(event)")
+                        model = "unexpected event \(event)"
+                        return []
                     }
                 }
             }

--- a/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
+++ b/MobiusExtras/Test/EventHandlerDisposalLogicalRaceRegressionTest.swift
@@ -62,9 +62,7 @@ class EventHandlerDisposalLogicalRaceRegressionTest: QuickSpec {
                     errorThrown = true
                 })
 
-                let update = Update<Model, Event, Effect> { _, _ in
-                    .dispatchEffects([.effect1])
-                }
+                let update = Update<Model, Event, Effect> { _, _ in [.effect1] }
 
                 controller = Mobius.loop(update: update, effectHandler: effectHandler)
                     .withEventSource(eventSource)

--- a/MobiusNimble/Test/NimbleNextMatchersTests.swift
+++ b/MobiusNimble/Test/NimbleNextMatchersTests.swift
@@ -48,8 +48,9 @@ class NimbleNextMatchersTests: QuickSpec {
                 NimbleAssertionHandler = defaultHandler!
             }
 
-            let testUpdate = Update<String, String, String> { _, _ in
-                .next("some model", effects: ["some effect"])
+            let testUpdate = Update<String, String, String> { model, _ in
+                model = "some model"
+                return ["some effect"]
             }
 
             // Testing through proxy: UpdateSpec

--- a/MobiusTest/Source/UpdateSpec.swift
+++ b/MobiusTest/Source/UpdateSpec.swift
@@ -58,16 +58,15 @@ public struct UpdateSpec<Model, Event, Effect> {
         }
 
         public func then(_ expression: Assert) {
-            var lastNext: Next<Model, Effect>?
+            var lastEffects: [Effect]?
             var lastModel = model
 
             for event in events {
-                lastNext = update.update(model: lastModel, event: event)
-                lastModel = lastNext?.model ?? lastModel
+                lastEffects = update.update(into: &lastModel, event: event)
             }
 
             // there will always be at least one event, so lastNext is guaranteed to have a value
-            expression(Result(model: lastModel, lastNext: lastNext!))
+            expression(Result(model: lastModel, lastNext: .next(lastModel, effects: lastEffects!)))
         }
     }
 

--- a/MobiusTest/Test/NextMatchersTests.swift
+++ b/MobiusTest/Test/NextMatchersTests.swift
@@ -42,7 +42,7 @@ class XCTestNextMatchersTests: QuickSpec {
                 failMessages = []
             }
 
-            let testUpdate = Update<String, String, String> { _, _ in
+            let testUpdate = Update<String, String, String>.create { _, _ in
                 .next("some model", effects: ["some effect"])
             }
 

--- a/MobiusTest/Test/UpdateSpecTests.swift
+++ b/MobiusTest/Test/UpdateSpecTests.swift
@@ -111,7 +111,7 @@ class UpdateSpecTests: QuickSpec {
         }
     }
 
-    let myUpdate = Update<MyModel, MyEvent, MyEffect> { model, event in
+    let myUpdate = Update<MyModel, MyEvent, MyEffect>.create { model, event in
         switch event {
         case .didTapButton:
             return Next.next(MyModel(buttonClicked: !model.buttonClicked, count: model.count + 1))


### PR DESCRIPTION
This changes the signature of `Update` to be of the form `(inout Model, Event) -> [Effect]` instead of `(Model, Event) -> (Model, [Effect])`.

Although it may seem that allowing mutation in the reducer is not something we want, it is in fact no different to returning a new model, thanks to Swift's value types. The mutation is locally scoped to just the invocation of this function, as opposed to reference type mutations, which can travel far and are not controlled.

There are two main benefits to doing this:

### Simpler reducers

Implementations of reducers can be simpler. Currently you must construct a new model to return from a reducer, which can be done in 3 different ways:

* Construct it from scratch each time:
     ```swift
     func update(model: MyModel, event: Event) -> Next<Model, Effect> {
       return Next(MyModel(id: model.id, name: model.name, isAdmin: true))
     }
     ```
    This can get really tedious for large models.
* Adopt a "builder" pattern for models:
     ```swift
     func update(model: MyModel, event: Event) -> Next<Model, Effect> {
       return Next(model.builder().isAdmin(true).build())
     }
     ```
     This requires some kind of code generation to give us access to these builder methods.
* Make a mutable copy, and then return it at the end:
     ```swift
     func update(model: MyModel, event: Event) -> Next<Model, Effect> {
       var model = model
       model.isAdmin = true
       return Next(model)
     }
     ```
    This is boilerplate that will be done in every reducer, and either requires shadowing the model or potentially having two different versions of the model in the scope of this function.

Alternatively, with `inout` we can just apply the mutations directly without any set up, and then return the effects:

```swift
func update(model: MyModel, event: Event) -> [Effect] {
  model.isAdmin = true
  return []
}
```

### More efficient reducers

Reducers no longer need to make entirely new copies of the model every time an event is dispatched. This may not always be a concern, but for very large models it could become a problem.
